### PR TITLE
[WIP] Hlt vertex reports

### DIFF
--- a/src/BankTypes.h
+++ b/src/BankTypes.h
@@ -79,4 +79,12 @@ enum class EBankType {
    LastType // LOOP Marker; add new bank types ONLY before!
 };
 
+#include <iostream>
+
+inline std::ostream &operator<<(std::ostream &os, const EBankType &bankType)
+{
+   os << static_cast<std::underlying_type<EBankType>::type>(bankType);
+   return os;
+}
+
 #endif // BANKTYPES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(mdfds TRecordReader.hxx TRecordReader.cxx TBankDecoder.hxx TDummyDecoder.cxx TMDFDataSource.hxx)
+add_library(mdfds TRecordReader.hxx TRecordReader.cxx TBankDecoder.hxx TDummyDecoder.cxx THltVertexReportsDecoder.cxx TMDFDataSource.hxx)
 target_link_libraries(mdfds ${ROOT_LIBRARIES})
 target_include_directories(mdfds PUBLIC ${ROOT_INCLUDE_DIRS})

--- a/src/TBankDecoder.hxx
+++ b/src/TBankDecoder.hxx
@@ -1,6 +1,7 @@
 #ifndef TBANKDECODER
 #define TBANKDECODER
 
+#include "BankTypes.h"
 #include <string>
 #include <typeinfo>
 #include <type_traits>
@@ -18,9 +19,9 @@ public:
    /// Retrieve the type info of this bank.
    virtual const std::type_info &GetTypeInfo() const = 0;
    /// Retrieve bank ID.
-   virtual int GetID() const = 0;
+   virtual EBankType GetID() const = 0;
    /// Take a bank body as raw bytes, put the encoding in the area of memory pointed by destination
-   virtual void Decode(const char *bank, void *destination) const = 0;
+   virtual void Decode(const std::vector<char> &bank, void *destination) const = 0;
    /// Allocate N objects of the correct type, after checking that we expect the right type
    virtual void *Allocate() const = 0;
    /// Deallocate objects by calling the destructor for the appropriate type

--- a/src/TBankDecoder.hxx
+++ b/src/TBankDecoder.hxx
@@ -7,6 +7,14 @@
 #include <type_traits>
 #include <vector>
 
+/// \brief General utility to reinterpret the memory associated to a certain value
+///  pun_to allows to reinterpret the memory associated to a variable without copies.
+template <typename T, typename U>
+inline T &pun_to(const U &x)
+{
+   return *(T *)&x;
+}
+
 /// \brief Abstract implementation of an MDF bank decoder.
 /// TMDFDataSource uses concrete TBankDecoder implementations to read banks.
 class TBankDecoder {

--- a/src/TDummyDecoder.hxx
+++ b/src/TDummyDecoder.hxx
@@ -8,8 +8,8 @@ public:
    std::string GetName() const final { return "dummy"; }
    std::string GetTypeName() const final { return "int"; }
    const std::type_info &GetTypeInfo() const { return typeid(int); }
-   int GetID() const final { return 123456; }
-   void Decode(const char *, void *destination) const final { *static_cast<int *>(destination) = 42; }
+   EBankType GetID() const final { return EBankType::LastType; }
+   void Decode(const std::vector<char> &, void *destination) const final { *static_cast<int *>(destination) = 42; }
    void *Allocate() const final;
    void Deallocate(void *obj) const final;
 };

--- a/src/THltVertexReports.hxx
+++ b/src/THltVertexReports.hxx
@@ -1,0 +1,22 @@
+#ifndef THLTVERTEXREPORTS
+#define THLTVERTEXREPORTS
+
+#include <vector>
+
+/// \brief The C++ representation of the HltVertexReports bank
+/// This struct is a SOA which represents the primary vertices of an event.
+struct THltVertexReports {
+   std::vector<float> x;
+   std::vector<float> y;
+   std::vector<float> z;
+   std::vector<float> chi2;
+   std::vector<unsigned int> ndof;
+   std::vector<float> cov_00;
+   std::vector<float> cov_11;
+   std::vector<float> cov_22;
+   std::vector<float> cov_01;
+   std::vector<float> cov_02;
+   std::vector<float> cov_12;
+};
+
+#endif

--- a/src/THltVertexReportsDecoder.cxx
+++ b/src/THltVertexReportsDecoder.cxx
@@ -1,0 +1,113 @@
+#include "THltVertexReportsDecoder.hxx"
+#include "BankTypes.h"
+#include "THltVertexReports.hxx"
+
+#include <iostream>
+#include <sstream>
+
+const std::type_info &THltVertexReportsDecoder::GetTypeInfo() const
+{
+   return typeid(THltVertexReports);
+};
+
+EBankType THltVertexReportsDecoder::GetID() const
+{
+   return EBankType::HltVertexReports;
+};
+
+struct TPVInfo {
+   float x;
+   float y;
+   float z;
+   float chi2;
+   unsigned int ndof;
+   float cov_00;
+   float cov_11;
+   float cov_22;
+   float cov_01;
+   float cov_02;
+   float cov_12;
+};
+
+// The structure of the bank can be inferred from
+// http://lhcb-doxygen.web.cern.ch/lhcb-doxygen/moore/latest/d0/da9/class_hlt_vertex_reports_decoder.html
+// (thanks to Rosen Matev for the help in understanding it!)
+// - (uint32) the number of "selections" (there can be different types of PVs, but normally this should be 1)
+// - for each selection:
+//   - (uint16) number of PVs
+//   - (uint16) "selection" ID
+//   - for each PV:
+//      - (float) x, (float) y, (float) z,  (float) chi2,  (uint32) ndof,
+//        (float) cov[0][0], (float) cov[1][1], (float) cov[2][2], (float) cov[0][1], (float) cov[0][2], (float)
+//        cov[1][2]
+// For simplicity, we'll consider only vertices with selection equal to 1.
+// An example record, in chars, looks like this one:
+//
+// 10000000 00000000 00000000 00000000         selections
+
+// 10000000 00000000 11900000 39000000         nvtx / selID
+
+// 4294967213 51000000 67000000 63000000       x
+// 93000000 35000000 4294967189 4294967229     y
+// 4294967175 4294967276 4294967173 4294967232 z
+
+// 44000000 4294967276 10000000 66000000       chi2
+// 12300000 00000000 00000000 00000000         ndof
+
+// 11500000 12700000 4294967202 56000000       cov_00
+// 72000000 4294967173 4294967182 56000000     cov_11
+// 4294967251 4294967203 18000000 59000000     cov_22
+// 11700000 86000000 64000000 53000000         cov_01
+// 77000000 90000000 22000000 4294967225       cov_02
+// 10500000 18000000 88000000 4294967223       cov_12
+
+void THltVertexReportsDecoder::Decode(const std::vector<char> &bank, void *destination) const
+{
+   auto &vReps = *reinterpret_cast<THltVertexReports *>(destination);
+
+   // Read the selection type
+   auto &nSel = pun_to<unsigned int>(bank[0]);
+   if (1U != nSel) {
+      std::cerr << "The number of HltVertexReports selections for this entry is not 1. Returning zero vertices."
+                << std::endl;
+      return;
+   }
+
+   auto &nPVs = pun_to<unsigned short>(bank[4]);
+   if (0 == nPVs) {
+      return;
+   }
+
+   vReps.ndof.reserve(nPVs);
+   for (auto v : {&vReps.x, &vReps.y, &vReps.z, &vReps.chi2, &vReps.cov_00, &vReps.cov_11, &vReps.cov_22, &vReps.cov_01,
+                  &vReps.cov_02, &vReps.cov_12}) {
+      v->reserve(nPVs);
+   }
+
+   // Now loop on the PVs
+   for (unsigned short i = 0; i < nPVs; ++i) {
+      auto offset = 8 + i * 11 * 4; // start of the first x, ith vtx * elements of info per vtx * size of element
+      auto &pvInfo = pun_to<TPVInfo>(bank[offset]);
+      vReps.x.emplace_back(pvInfo.x);
+      vReps.y.emplace_back(pvInfo.y);
+      vReps.z.emplace_back(pvInfo.z);
+      vReps.chi2.emplace_back(pvInfo.chi2);
+      vReps.ndof.emplace_back(pvInfo.ndof);
+      vReps.cov_00.emplace_back(pvInfo.cov_00);
+      vReps.cov_11.emplace_back(pvInfo.cov_11);
+      vReps.cov_22.emplace_back(pvInfo.cov_22);
+      vReps.cov_01.emplace_back(pvInfo.cov_01);
+      vReps.cov_02.emplace_back(pvInfo.cov_02);
+      vReps.cov_12.emplace_back(pvInfo.cov_12);
+   }
+}
+
+void *THltVertexReportsDecoder::Allocate() const
+{
+   return new THltVertexReports();
+};
+
+void THltVertexReportsDecoder::Deallocate(void *obj) const
+{
+   delete reinterpret_cast<THltVertexReports *>(obj);
+};

--- a/src/THltVertexReportsDecoder.hxx
+++ b/src/THltVertexReportsDecoder.hxx
@@ -1,0 +1,20 @@
+#ifndef THLTVERTEXREPORTSDECODER
+#define THLTVERTEXREPORTSDECODER
+
+#include "TBankDecoder.hxx"
+
+/// \brief Implements the decoding of the HltVertexReports bank
+/// With this class, all the useful information from the HltVertexReports bank is extracted.
+class THltVertexReportsDecoder final : public TBankDecoder {
+public:
+   ~THltVertexReportsDecoder() {}
+   std::string GetName() const { return "HltVertexReports"; };     // TODO: shouldn't this be a const ref?
+   std::string GetTypeName() const { return "HltVertexReports"; }; // TODO: shouldn't this be a const ref?
+   const std::type_info &GetTypeInfo() const;
+   EBankType GetID() const;
+   void Decode(const std::vector<char> &bank, void *destination) const;
+   void *Allocate() const;
+   void Deallocate(void *obj) const;
+};
+
+#endif

--- a/src/TMDFDataSource.hxx
+++ b/src/TMDFDataSource.hxx
@@ -24,7 +24,7 @@ class TMDFDataSource : public ROOT::Experimental::TDF::TDataSource {
    /// List of decoder names (i.e. column names), with the same ordering as the decoders in fDecoders
    const std::vector<std::string> fDecoderNames;
    /// List of decoder ids (i.e. bank type), with same ordering as the decoders in fDecoders
-   const std::vector<int> fDecoderIDs;
+   const std::vector<EBankType> fDecoderIDs;
    /// List of files we will loop over
    const std::vector<std::string> fFileNames;
    /// Index of the current file being processed in fFileNames
@@ -133,7 +133,7 @@ private:
    }
 
    template <int... S>
-   std::vector<int> GetDecoderIDs(ROOT::Internal::TDF::StaticSeq<S...>) const
+   std::vector<EBankType> GetDecoderIDs(ROOT::Internal::TDF::StaticSeq<S...>) const
    {
       return {std::get<S>(fDecoders).GetID()...};
    }

--- a/src/TRecordReader.cxx
+++ b/src/TRecordReader.cxx
@@ -96,7 +96,8 @@ unsigned int TRecordReader::EvalRecordSize()
       return 0u;
 }
 
-std::vector<char> TRecordReader::GetBankBody() {
+std::vector<char> TRecordReader::GetBankBody()
+{
    const auto bankSize = fBankHeader.size;
    if (bankSize == 0u) {
       std::cerr << "warning: bank body requested, but no bank has been read for this record yet. Please call "

--- a/src/TRecordReader.hxx
+++ b/src/TRecordReader.hxx
@@ -1,13 +1,15 @@
 #ifndef TRECORDREADER
 #define TRECORDREADER
 
+#include "BankTypes.h"
+
 #include <fstream> // std::filebuf
 #include <vector>
 
 struct BankHeader {
-   unsigned int size = 0u;    // actually 16 bits
-   unsigned int type = 0u;    // actually 8 bits
-   unsigned int version = 0u; // actually 8 bits
+   unsigned int size = 0u;               // actually 16 bits
+   EBankType type = EBankType::LastType; // actually 8 bits
+   unsigned int version = 0u;            // actually 8 bits
 };
 
 class TRecordReader {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ endfunction()
 
 add_google_test(mdfds_test mdfds_test.cxx)
 add_google_test(recordreader_test recordreader.cxx)
+add_google_test(hltvertexreports_test hltvertexreports.cxx)
 
 # copy dataset to binary dir
 configure_file(${CMAKE_SOURCE_DIR}/tests/small.raw ${CMAKE_BINARY_DIR}/tests/small.raw COPYONLY)

--- a/tests/hltvertexreports.cxx
+++ b/tests/hltvertexreports.cxx
@@ -1,0 +1,68 @@
+#include <BankTypes.h>
+#include <THltVertexReports.hxx>
+#include <THltVertexReportsDecoder.hxx>
+#include <TRecordReader.hxx>
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <iomanip>
+
+const auto fname = "small.raw";
+
+struct with_width {
+   int w;
+   with_width(int w) : w(w) {}
+};
+auto operator<<(std::ostream &os, const with_width &w) -> decltype(os << std::setw(0) << std::left)
+{
+   return os << std::setw(w.w) << std::left;
+}
+
+TEST(THltVertexReportsDecoder, DecodeHltVertexReportsBanks)
+{
+   THltVertexReportsDecoder pvDecoder;
+   TRecordReader r(fname);
+   for (auto recordn = 0u; r.NextRecord(); ++recordn) {
+      for (auto bankn = 0u; r.NextBank(); ++bankn) {
+         auto bankHeader = r.GetBankHeader();
+         // We now test the vertices
+         if (bankHeader.type != EBankType::HltVertexReports) {
+            continue;
+         }
+
+         std::cout << "record " << with_width(7) << recordn << "bank " << with_width(7) << bankn
+                   << " pos: " << with_width(10) << r.GetBankPosition() << " size: " << with_width(7) << bankHeader.size
+                   << " type: " << with_width(7) << bankHeader.type << " version: " << with_width(7)
+                   << bankHeader.version << '\n';
+
+         auto bankBody = r.GetBankBody();
+         auto pvsPtr = (THltVertexReports *)pvDecoder.Allocate();
+         auto &pvs = *pvsPtr;
+         pvDecoder.Decode(bankBody, (void *)pvsPtr);
+         auto nPvs = pvs.x.size();
+         std::cout << "Found " << nPvs << " primary vertices:" << std::endl;
+         for (size_t i = 0; i < nPvs; ++i) {
+            std::cout << " - Vtx " << i << ": "
+                      << "x = " << pvs.x[i] << " "
+                      << "y = " << pvs.y[i] << " "
+                      << "z = " << pvs.z[i] << " "
+                      << "chi2 = " << pvs.chi2[i] << " "
+                      << "ndof = " << pvs.ndof[i] << " "
+                      << "cov_00 = " << pvs.cov_00[i] << " "
+                      << "cov_11 = " << pvs.cov_11[i] << " "
+                      << "cov_22 = " << pvs.cov_22[i] << " "
+                      << "cov_01 = " << pvs.cov_01[i] << " "
+                      << "cov_02 = " << pvs.cov_02[i] << " "
+                      << "cov_12 = " << pvs.cov_12[i] << std::endl;
+         }
+
+         pvDecoder.Deallocate(pvsPtr);
+      }
+   }
+}
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
First attempt to get the decoding of vertices done. The data structure chosen to represent the vertices in memory is a simple SOA, as discussed.
The problem encountered lies in the interpretation of the bank body.
The description provided by Rosen is:
```
- (uint32) the number of "selections" (there can be different types of PVs, but normally this should be 1)
  - for each selection:
    - (uint16) number of PVs
    - (uint16) "selection" ID
    - for each PV:
      - (float) x, (float) y, (float) z,  (float) chi2,  (uint32) ndof, (float) cov[0][0], (float) cov[1][1], (float) cov[2][2], (float) cov[0][1], (float) cov[0][2], (float) cov[1][2]
```
On the other hand, this is what we see for a bank with a single vertex (every bunch of numbers is a `char` printed with `std::hex`):
```
// 10000000 00000000 00000000 00000000         selections

// 10000000 00000000 11900000 39000000         nvtx / selID

// 4294967213 51000000 67000000 63000000       x
// 93000000 35000000 4294967189 4294967229     y
// 4294967175 4294967276 4294967173 4294967232 z

// 44000000 4294967276 10000000 66000000       chi2
// 12300000 00000000 00000000 00000000         ndof

// 11500000 12700000 4294967202 56000000       cov_00
// 72000000 4294967173 4294967182 56000000     cov_11
// 4294967251 4294967203 18000000 59000000     cov_22
// 11700000 86000000 64000000 53000000         cov_01
// 77000000 90000000 22000000 4294967225       cov_02
// 10500000 18000000 88000000 4294967223       cov_12
```
Something is not consistent. There are some points to clarify.